### PR TITLE
Bugfix to service resource, improvements to ingress and other resources

### DIFF
--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -101,6 +101,13 @@ Secret name
 {{- end }}
 
 {{/*
+Service name
+*/}}
+{{- define "kubetail.serviceName" -}}
+{{ if .Values.kubetail.service.name }}{{ .Values.kubetail.service.name }}{{ else }}{{ include "kubetail.fullname" . }}{{ end }}
+{{- end }}
+
+{{/*
 Kubetail config
 */}}
 {{- define "kubetail.config" -}}

--- a/charts/kubetail/templates/ingress.yaml
+++ b/charts/kubetail/templates/ingress.yaml
@@ -16,9 +16,22 @@ metadata:
     {{- end }}
 spec:
   rules:
-  {{- with $ing.rules }}
-  {{- toYaml . | nindent 2 }}
-  {{- end }}
+  {{- range $ing.rules }}
+  - host: {{ tpl .host $ }}
+    http:
+      {{- with .http }}
+      paths:
+      {{- range .paths }}
+      - path: {{ .path }}
+        pathType: {{ .pathType }}
+        backend:
+          service:
+            name: {{ include "kubetail.serviceName" $ }}
+            port:
+              name: kubetail
+      {{- end }}
+      {{- end }}
+  {{- end}}
   tls:
   {{- with $ing.tls }}
   {{- toYaml . | nindent 2 }}

--- a/charts/kubetail/templates/service-account.yaml
+++ b/charts/kubetail/templates/service-account.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 apiVersion: v1
 automountServiceAccountToken: {{ $sa.automountServiceAccountToken }}
 metadata:
-  name: {{ $sa.name | default (include "kubetail.fullname" .) }}
+  name: {{ include "kubetail.serviceAccountName" . }}
   namespace: {{ include "kubetail.namespace" . }}
   labels:
     {{- include "kubetail.labels" . | nindent 4 }}

--- a/charts/kubetail/templates/service.yaml
+++ b/charts/kubetail/templates/service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ $svc.name | default (include "kubetail.fullname" .) }}
+  name: {{ include "kubetail.serviceName" . }}
   namespace: {{ include "kubetail.namespace" . }}
   labels:
     {{- include "kubetail.labels" . | nindent 4 }}
@@ -20,5 +20,6 @@ spec:
   ports:
   - name: kubetail
     protocol: TCP
-    appProtocol: http
     port: {{ $svc.port }}
+    targetPort: kubetail
+    appProtocol: http


### PR DESCRIPTION
* Adds missing `targetPort` to service resource template
* Adds backend to ingress resource template
* Improves handling of `serviceAccountName` internally

Fixes https://github.com/kubetail-org/helm-charts/issues/40
