### PR TITLE
bugfix: helm deploy fails to deploy roleBindings with multiple namespaces

### DIFF
--- a/charts/kubetail/templates/agent/rbac.yaml
+++ b/charts/kubetail/templates/agent/rbac.yaml
@@ -33,6 +33,7 @@ subjects:
   namespace: {{ include "kubetail.namespace" . }}
 {{- else }}
 {{- range .Values.kubetail.allowedNamespaces }}
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
When `allowedNamespaces` contains more than one namespace, the helm deploy throws some warnings. For example, with two namespaces you get this:

```
W1210 11:32:10.460182 1756386 warnings.go:70] unknown field "roleRef"
W1210 11:32:10.460205 1756386 warnings.go:70] unknown field "subjects"
```

The deploy otherwise succeeds, but in the UI we get errors saying that there aren't enough permissions on one of our namespaces. Looking at what's deployed, one of the roleBindings is missing.

I think whats happened is that the first roleBinding and the subsequent role get munged together because theres no separation between them. Ive added a separation akin to that on the server/rbac file [here](https://github.com/kubetail-org/helm-charts/blob/376f4f97d221d54021c9235066b4c4694ec42c4f/charts/kubetail/templates/server/rbac.yaml#L39)