### PR TITLE
🎣 Fix issue with new ClusterAgent dispatch-url config location

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kubetail
-description: Real-time logging dashboard for Kubernetes
+description: General-purpose logging dashboard for Kubernetes
 keywords:
 - kubetail
 - kubernetes
@@ -8,7 +8,7 @@ keywords:
 - private
 - realtime
 type: application
-version: 0.13.3-rc1
+version: 0.13.3-rc2
 appVersion: "0.13.3-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -281,15 +281,17 @@ app.kubernetes.io/component: "cluster-api"
 Cluster API config
 */}}
 {{- define "kubetail.clusterAPI.config" -}}
+{{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
+{{- $dispatchUrl := printf "kubernetes://%s:%d" (include "kubetail.clusterAgent.serviceName" $) $dispatchUrlPort }}
 {{- with .Values.kubetail.allowedNamespaces }}
 allowed-namespaces: 
 {{- toYaml . | nindent 0 }}
 {{- end }}
 cluster-api:
   addr: :{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
-  cluster-agent-dispatch-url: "kubernetes://{{ include "kubetail.clusterAgent.serviceName" $ }}:{{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}"
   {{- $cfg := omit .Values.kubetail.clusterAPI.runtimeConfig "ports" "http"}}
   {{- $_ := set $cfg.csrf "secret" "${KUBETAIL_CLUSTER_API_CSRF_SECRET}" }}
+  {{- $_ := set $cfg "clusterAgent" ( dict "dispatchUrl" $dispatchUrl )}}
   {{- include "kubetail.toKebabYaml" $cfg | nindent 2 }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

Fix issue with new ClusterAgent dispatch-url config location

## Changes

* Updated helpers.tmpl, move dispatch-url to sub-dict

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
