### PR TITLE
🐋 Improve helm-charts workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,8 @@ permissions:
 
 on:
   push:
-    branches:
-      - publish
+    tags:
+      - 'kubetail-*'
 
 jobs:
   release:
@@ -67,6 +67,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
+        with:
+          version: v3.11.2
 
       - name: Create quickstart manifests
         run: |


### PR DESCRIPTION
Fixes [#602](https://github.com/kubetail-org/kubetail/issues/602)

## Summary

Fixed a warning in attach-manifests job and changed the release workflow trigger.

## Changes

- A warning resulted from [azure/setup-helm@v3's](https://github.com/azure/setup-helm/tree/v3/) default version requiring GITHUB_TOKEN has been fixed by supplying a version number.
- The release workflow trigger is changed from push on publish branch to new tags of the form `kubetail-<version>`.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [x] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
