### PR TITLE
🐋 Bump dashboard to 0.11.0 and cluster-api to 0.5.5

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.19.0
-appVersion: "0.18.3"
+version: 0.20.0
+appVersion: "0.19.0"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -102,7 +102,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.10.2"
+      tag: "0.11.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -280,7 +280,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.5.4"
+      tag: "0.5.5"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Bump kubetail component image tags to their latest releases: dashboard from 0.10.2 to 0.11.0 and cluster-api from 0.5.4 to 0.5.5. Chart version bumped to 0.20.0 (minor bump due to dashboard minor version change).

## Key Changes

- Update dashboard image tag from 0.10.2 to 0.11.0
- Update cluster-api image tag from 0.5.4 to 0.5.5
- Bump chart version from 0.19.0 to 0.20.0 and appVersion from 0.18.3 to 0.19.0

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused