### PR TITLE
🐋 Bump dashboard to 0.12.0 and cluster-api to 0.5.6

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.20.0
-appVersion: "0.19.0"
+version: 0.21.0
+appVersion: "0.20.0"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -102,7 +102,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.11.0"
+      tag: "0.12.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -280,7 +280,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.5.5"
+      tag: "0.5.6"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Bump kubetail component image tags to their latest releases: dashboard from 0.11.0 to 0.12.0 and cluster-api from 0.5.5 to 0.5.6. No config changes were needed. Chart version bumped to 0.21.0 and appVersion to 0.20.0.

## Key Changes

- Update dashboard image tag from 0.11.0 to 0.12.0
- Update cluster-api image tag from 0.5.5 to 0.5.6
- Bump chart version to 0.21.0 and appVersion to 0.20.0

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused