### PR TITLE
🐋 Bump dashboard to 0.12.1

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.21.0
-appVersion: "0.20.0"
+version: 0.21.1
+appVersion: "0.20.1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -102,7 +102,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.12.0"
+      tag: "0.12.1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Bump the kubetail dashboard component to v0.12.1. No config changes were needed — this is a patch-level image tag update.

## Key Changes

- Update dashboard image tag from `0.12.0` to `0.12.1`
- Bump chart version from `0.21.0` to `0.21.1` and appVersion from `0.20.0` to `0.20.1`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused