### PR TITLE
🐋 Bump dashboard to 0.13.0 and cluster-api to 0.6.0

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.21.1
-appVersion: "0.20.1"
+version: 0.22.0-rc1
+appVersion: "0.21.0-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -50,10 +50,6 @@ kubetail:
       basePath: /
       # -- Sets the mode for the Gin framework
       ginMode: "release"
-      # -- CSRF options
-      csrf:
-        # -- Enables/disables csrf protection
-        enabled: true
       # -- Logging options
       logging:
         # -- Enables/disables logging
@@ -102,7 +98,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.12.1"
+      tag: "0.13.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -246,10 +242,6 @@ kubetail:
       basePath: /
       # -- Sets the mode for the Gin framework
       ginMode: "release"
-      # -- CSRF options
-      csrf:
-        # -- Enables/disables csrf protection
-        enabled: true
       # -- Logging options
       logging:
         # -- Enables/disables logging
@@ -280,7 +272,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.5.6"
+      tag: "0.6.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Updates the bundled Kubetail components to their latest releases. The dashboard moves from 0.12.1 to 0.13.0 and the cluster-api moves from 0.5.6 to 0.6.0. Both upstream releases removed the `CSRF` config struct, so the corresponding values entries are dropped from `values.yaml` so rendered ConfigMaps stay aligned with the new schemas. The cluster-agent is unchanged at 0.6.2.

## Key Changes

- Bump `kubetail.dashboard.image.tag` to `0.13.0`.
- Bump `kubetail.clusterAPI.image.tag` to `0.6.0`.
- Remove `kubetail.dashboard.runtimeConfig.csrf` and `kubetail.clusterAPI.runtimeConfig.csrf` to match upstream config struct changes.
- Bump chart `version` to `0.22.0-rc1` and `appVersion` to `"0.21.0-rc1"`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused