### PR TITLE
🐋 Release kubetail-0.22.0

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.22.0-rc1
-appVersion: "0.21.0-rc1"
+version: 0.22.0
+appVersion: "0.21.0"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com


### PR DESCRIPTION
## Summary

Promotes the chart from `0.22.0-rc1` to the stable `0.22.0` release, with the bundled Kubetail app version graduating from `0.21.0-rc1` to `0.21.0`.

## Key Changes

- Bumps `version` in `charts/kubetail/Chart.yaml` from `0.22.0-rc1` to `0.22.0`.
- Bumps `appVersion` in `charts/kubetail/Chart.yaml` from `0.21.0-rc1` to `0.21.0`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused