### PR TITLE
🐋 Release kubetail-0.22.1-rc1

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.22.0
-appVersion: "0.21.0"
+version: 0.22.1-rc1
+appVersion: "0.21.1-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -98,7 +98,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.13.0"
+      tag: "0.13.1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Cut release candidate 0.22.1-rc1 of the kubetail chart to ship the kubetail dashboard 0.13.1 patch.

## Key Changes

- Bump chart version to 0.22.1-rc1 and appVersion to 0.21.1-rc1
- Bump dashboard image tag to 0.13.1

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused