### PR TITLE
🐋 Bump dashboard to 0.14.0-rc3 and cluster-api to 0.6.1-rc2

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.23.0-rc1
-appVersion: "0.22.0-rc1"
+version: 0.23.0-rc2
+appVersion: "0.22.0-rc2"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -55,6 +55,8 @@ kubetail:
         http: 8080
       # -- Sets the url path prefix (useful for deploying on a sub-path behind a reverse proxy)
       basePath: /
+      # -- List of allowed origin URLs for use in same-origin checks with WebSocket connections behind proxies
+      allowedOrigins: []
       # -- Sets the mode for the Gin framework
       ginMode: "release"
       # -- Logging options
@@ -105,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.14.0-rc2"
+      tag: "0.14.0-rc3"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -279,7 +281,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.6.1-rc1"
+      tag: "0.6.1-rc2"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Bumps the kubetail dashboard and cluster-api images to their latest release candidates and exposes a new dashboard runtime config option.

## Key Changes

- Bump `kubetail.dashboard.image.tag` from `0.14.0-rc2` to `0.14.0-rc3`
- Bump `kubetail.clusterAPI.image.tag` from `0.6.1-rc1` to `0.6.1-rc2`
- Add `kubetail.dashboard.runtimeConfig.allowedOrigins` (defaults to `[]`) — list of allowed origin URLs used for same-origin checks on WebSocket connections behind proxies; introduced by the dashboard's new `allowed-origins` config field
- Bump chart `version` to `0.23.0-rc2` and `appVersion` to `0.22.0-rc2`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused