### PR TITLE
✨ Bump dashboard to 0.14.0 and cluster-api to 0.7.0

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.23.0-rc2
-appVersion: "0.22.0-rc2"
+version: 0.23.0
+appVersion: "0.22.0"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -107,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.14.0-rc3"
+      tag: "0.14.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -281,7 +281,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.6.1-rc2"
+      tag: "0.7.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Graduate the kubetail components to stable releases. The dashboard moves from `0.14.0-rc3` to `0.14.0` (rc promotion with no code changes), and cluster-api bumps from `0.6.1-rc2` to `0.7.0` (minor version). The component config structs at the new tags are byte-identical to the rc tags, so no `runtimeConfig` changes are required. The chart itself graduates from `0.23.0-rc2` to `0.23.0` stable, with `appVersion` moving from `0.22.0-rc2` to `0.22.0`.

## Key Changes

- Bump `kubetail.dashboard.image.tag` from `0.14.0-rc3` to `0.14.0`
- Bump `kubetail.clusterAPI.image.tag` from `0.6.1-rc2` to `0.7.0`
- Bump chart `version` from `0.23.0-rc2` to `0.23.0`
- Bump chart `appVersion` from `0.22.0-rc2` to `0.22.0`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused