### PR TITLE
🐋 Bump kubetail to 0.24.0-rc1

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.23.0
-appVersion: "0.22.0"
+version: 0.24.0-rc1
+appVersion: "0.23.0-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -44,15 +44,24 @@ TLS bundle for cluster-api ↔ cluster-agent mTLS.
 
 Generates a self-signed CA plus three leaf certs (cluster-api server cert,
 cluster-api client cert, cluster-agent server cert). Persists across upgrades
-by recovering values from the existing TLS secrets via `lookup`. If any piece
-is missing (fresh install, or a secret was deleted), regenerates the entire
-bundle so we never end up with orphan leaves signed by a vanished CA.
+by recovering values from the existing TLS secrets via `lookup`.
+
+Renewal logic, by component:
+  - CA: long-lived (10y); reused as long as both ca.crt and ca.key are
+    present in the cluster-api secret. If the CA is missing (fresh install
+    or secret deleted), the entire bundle is regenerated so we never end up
+    with orphan leaves signed by a vanished CA.
+  - Leaves (api/client/agent): regenerated under the existing CA when any
+    leaf piece is missing, when the recorded `not-after` is absent (e.g.
+    pre-renewal-tracking installs), or when the recorded expiry is within
+    the renewal window. Otherwise the cached leaves are reused verbatim so
+    repeat renders produce stable output.
 
 Cached on `.Values` so multiple includes within a single render return the
 same bundle (otherwise each Secret template would generate its own CA).
 
 Returns a dict (as YAML) with: caCert, caKey, apiCert, apiKey, clientCert,
-clientKey, agentCert, agentKey.
+clientKey, agentCert, agentKey, notAfter (Unix epoch seconds, as string).
 */}}
 {{- define "kubetail.tlsBundle" -}}
 {{- $cached := index .Values "_kubetailTlsBundle" -}}
@@ -76,13 +85,27 @@ clientKey, agentCert, agentKey.
   {{- $apiKeyB64 := index $apiData "tls.key" -}}
   {{- $clientCertB64 := index $apiData "client.crt" -}}
   {{- $clientKeyB64 := index $apiData "client.key" -}}
+  {{- $notAfterB64 := index $apiData "not-after" -}}
   {{- $agentCertB64 := index $agentData "tls.crt" -}}
   {{- $agentKeyB64 := index $agentData "tls.key" -}}
 
-  {{- $hasAll := and (and (and $caCertB64 $caKeyB64) (and $apiCertB64 $apiKeyB64)) (and (and $clientCertB64 $clientKeyB64) (and $agentCertB64 $agentKeyB64)) -}}
+  {{- $leafDays := 3650 -}}
+  {{- $renewBeforeSec := mul 365 86400 -}}
+  {{- $nowUnix := now.Unix | int -}}
+
+  {{- $hasCA := and $caCertB64 $caKeyB64 -}}
+  {{- $hasLeaves := and (and $apiCertB64 $apiKeyB64) (and (and $clientCertB64 $clientKeyB64) (and $agentCertB64 $agentKeyB64)) -}}
+
+  {{- $leavesValid := false -}}
+  {{- if and $hasLeaves $notAfterB64 -}}
+    {{- $notAfterUnix := b64dec $notAfterB64 | atoi -}}
+    {{- if gt (sub $notAfterUnix $nowUnix) $renewBeforeSec -}}
+      {{- $leavesValid = true -}}
+    {{- end -}}
+  {{- end -}}
 
   {{- $bundle := dict -}}
-  {{- if $hasAll -}}
+  {{- if and $hasCA $leavesValid -}}
     {{- $bundle = dict
       "caCert" (b64dec $caCertB64)
       "caKey" (b64dec $caKeyB64)
@@ -92,14 +115,21 @@ clientKey, agentCert, agentKey.
       "clientKey" (b64dec $clientKeyB64)
       "agentCert" (b64dec $agentCertB64)
       "agentKey" (b64dec $agentKeyB64)
+      "notAfter" (b64dec $notAfterB64)
     -}}
   {{- else -}}
-    {{- $ca := genCA "kubetail-ca" 3650 -}}
+    {{- $ca := dict -}}
+    {{- if $hasCA -}}
+      {{- $ca = dict "Cert" (b64dec $caCertB64) "Key" (b64dec $caKeyB64) -}}
+    {{- else -}}
+      {{- $ca = genCA "kubetail-ca" 3650 -}}
+    {{- end -}}
     {{- $apiSANs := list $apiSvc (printf "%s.%s" $apiSvc $ns) (printf "%s.%s.svc" $apiSvc $ns) (printf "%s.%s.svc.cluster.local" $apiSvc $ns) -}}
-    {{- $apiLeaf := genSignedCert $apiSvc nil $apiSANs 365 $ca -}}
-    {{- $clientLeaf := genSignedCert "kubetail-cluster-api" nil (list "kubetail-cluster-api") 365 $ca -}}
+    {{- $apiLeaf := genSignedCert $apiSvc nil $apiSANs $leafDays $ca -}}
+    {{- $clientLeaf := genSignedCert "kubetail-cluster-api" nil (list "kubetail-cluster-api") $leafDays $ca -}}
     {{- $agentSANs := list $agentSvc (printf "%s.%s" $agentSvc $ns) (printf "%s.%s.svc" $agentSvc $ns) (printf "%s.%s.svc.cluster.local" $agentSvc $ns) (printf "*.%s.%s.svc.cluster.local" $agentSvc $ns) -}}
-    {{- $agentLeaf := genSignedCert $agentSvc nil $agentSANs 365 $ca -}}
+    {{- $agentLeaf := genSignedCert $agentSvc nil $agentSANs $leafDays $ca -}}
+    {{- $notAfter := add $nowUnix (mul $leafDays 86400) -}}
     {{- $bundle = dict
       "caCert" $ca.Cert
       "caKey" $ca.Key
@@ -109,6 +139,7 @@ clientKey, agentCert, agentKey.
       "clientKey" $clientLeaf.Key
       "agentCert" $agentLeaf.Cert
       "agentKey" $agentLeaf.Key
+      "notAfter" (printf "%d" $notAfter)
     -}}
   {{- end -}}
   {{- $_ := set .Values "_kubetailTlsBundle" $bundle -}}
@@ -370,16 +401,20 @@ app.kubernetes.io/component: "cluster-api"
 Cluster API config
 */}}
 {{- define "kubetail.clusterAPI.config" -}}
+{{- $agentSvc := include "kubetail.clusterAgent.serviceName" $ }}
 {{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
-{{- $dispatchUrl := printf "kubernetes://%s:%d" (include "kubetail.clusterAgent.serviceName" $) $dispatchUrlPort }}
+{{- $dispatchUrl := printf "kubernetes://%s:%d" $agentSvc $dispatchUrlPort }}
 {{- with .Values.kubetail.allowedNamespaces }}
-allowed-namespaces: 
+allowed-namespaces:
 {{- toYaml . | nindent 0 }}
 {{- end }}
 addr: :{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
 {{- $cfg := omit .Values.kubetail.clusterAPI.runtimeConfig "ports" "http"}}
 {{- $clusterAgentCfg := deepCopy (default dict $cfg.clusterAgent) }}
 {{- $_ := set $clusterAgentCfg "dispatchUrl" $dispatchUrl }}
+{{- $tlsCfg := deepCopy (default dict $clusterAgentCfg.tls) }}
+{{- $_ := set $tlsCfg "serverName" (default $agentSvc $tlsCfg.serverName) }}
+{{- $_ := set $clusterAgentCfg "tls" $tlsCfg }}
 {{- $_ := set $cfg "clusterAgent" $clusterAgentCfg }}
 {{- include "kubetail.toKebabYaml" $cfg | nindent 0 }}
 {{- end }}

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -40,6 +40,85 @@ Print the namespace
 {{/**************** Shared helpers ****************/}}
 
 {{/*
+TLS bundle for cluster-api ↔ cluster-agent mTLS.
+
+Generates a self-signed CA plus three leaf certs (cluster-api server cert,
+cluster-api client cert, cluster-agent server cert). Persists across upgrades
+by recovering values from the existing TLS secrets via `lookup`. If any piece
+is missing (fresh install, or a secret was deleted), regenerates the entire
+bundle so we never end up with orphan leaves signed by a vanished CA.
+
+Cached on `.Values` so multiple includes within a single render return the
+same bundle (otherwise each Secret template would generate its own CA).
+
+Returns a dict (as YAML) with: caCert, caKey, apiCert, apiKey, clientCert,
+clientKey, agentCert, agentKey.
+*/}}
+{{- define "kubetail.tlsBundle" -}}
+{{- $cached := index .Values "_kubetailTlsBundle" -}}
+{{- if not $cached -}}
+  {{- $ns := include "kubetail.namespace" . -}}
+  {{- $apiSvc := include "kubetail.clusterAPI.serviceName" . -}}
+  {{- $agentSvc := include "kubetail.clusterAgent.serviceName" . -}}
+  {{- $apiSecretName := include "kubetail.clusterAPI.tlsSecretName" . -}}
+  {{- $agentSecretName := include "kubetail.clusterAgent.tlsSecretName" . -}}
+
+  {{- $apiExisting := (lookup "v1" "Secret" $ns $apiSecretName) -}}
+  {{- $agentExisting := (lookup "v1" "Secret" $ns $agentSecretName) -}}
+  {{- $apiData := dict -}}
+  {{- $agentData := dict -}}
+  {{- if $apiExisting -}}{{- $apiData = ($apiExisting.data | default dict) -}}{{- end -}}
+  {{- if $agentExisting -}}{{- $agentData = ($agentExisting.data | default dict) -}}{{- end -}}
+
+  {{- $caCertB64 := index $apiData "ca.crt" -}}
+  {{- $caKeyB64 := index $apiData "ca.key" -}}
+  {{- $apiCertB64 := index $apiData "tls.crt" -}}
+  {{- $apiKeyB64 := index $apiData "tls.key" -}}
+  {{- $clientCertB64 := index $apiData "client.crt" -}}
+  {{- $clientKeyB64 := index $apiData "client.key" -}}
+  {{- $agentCertB64 := index $agentData "tls.crt" -}}
+  {{- $agentKeyB64 := index $agentData "tls.key" -}}
+
+  {{- $hasAll := and (and (and $caCertB64 $caKeyB64) (and $apiCertB64 $apiKeyB64)) (and (and $clientCertB64 $clientKeyB64) (and $agentCertB64 $agentKeyB64)) -}}
+
+  {{- $bundle := dict -}}
+  {{- if $hasAll -}}
+    {{- $bundle = dict
+      "caCert" (b64dec $caCertB64)
+      "caKey" (b64dec $caKeyB64)
+      "apiCert" (b64dec $apiCertB64)
+      "apiKey" (b64dec $apiKeyB64)
+      "clientCert" (b64dec $clientCertB64)
+      "clientKey" (b64dec $clientKeyB64)
+      "agentCert" (b64dec $agentCertB64)
+      "agentKey" (b64dec $agentKeyB64)
+    -}}
+  {{- else -}}
+    {{- $ca := genCA "kubetail-ca" 3650 -}}
+    {{- $apiSANs := list $apiSvc (printf "%s.%s" $apiSvc $ns) (printf "%s.%s.svc" $apiSvc $ns) (printf "%s.%s.svc.cluster.local" $apiSvc $ns) -}}
+    {{- $apiLeaf := genSignedCert $apiSvc nil $apiSANs 365 $ca -}}
+    {{- $clientLeaf := genSignedCert "kubetail-cluster-api" nil (list "kubetail-cluster-api") 365 $ca -}}
+    {{- $agentSANs := list $agentSvc (printf "%s.%s" $agentSvc $ns) (printf "%s.%s.svc" $agentSvc $ns) (printf "%s.%s.svc.cluster.local" $agentSvc $ns) (printf "*.%s.%s.svc.cluster.local" $agentSvc $ns) -}}
+    {{- $agentLeaf := genSignedCert $agentSvc nil $agentSANs 365 $ca -}}
+    {{- $bundle = dict
+      "caCert" $ca.Cert
+      "caKey" $ca.Key
+      "apiCert" $apiLeaf.Cert
+      "apiKey" $apiLeaf.Key
+      "clientCert" $clientLeaf.Cert
+      "clientKey" $clientLeaf.Key
+      "agentCert" $agentLeaf.Cert
+      "agentKey" $agentLeaf.Key
+    -}}
+  {{- end -}}
+  {{- $_ := set .Values "_kubetailTlsBundle" $bundle -}}
+  {{- $cached = $bundle -}}
+{{- end -}}
+{{- $cached | toYaml -}}
+{{- end -}}
+
+
+{{/*
 Print key/value quoted pairs
 */}}
 {{- define "kubetail.printDict" -}}
@@ -140,12 +219,8 @@ allowed-namespaces:
 {{- end }}
 addr: :{{ .Values.kubetail.dashboard.runtimeConfig.ports.http }}
 auth-mode: {{ .Values.kubetail.dashboard.authMode }}
-{{- if .Values.kubetail.clusterAPI.enabled }}
-cluster-api-endpoint: "{{ if .Values.kubetail.clusterAPI.runtimeConfig.tls.enabled }}https{{ else }}http{{ end }}://{{ include "kubetail.clusterAPI.serviceName" $ }}:{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}"
-{{- end }}
+cluster-api-enabled: {{ .Values.kubetail.clusterAPI.enabled }}
 environment: cluster
-ui:
-  cluster-api-enabled: {{ .Values.kubetail.clusterAPI.enabled }}
 {{- $cfg := omit .Values.kubetail.dashboard.runtimeConfig "ports" "http" }}
 {{- $secrets := .Values.kubetail.secrets | default dict }}
 {{- $keyPairs := list (dict "signingKey" "${KUBETAIL_DASHBOARD_SESSION_SIGNING_KEY1}" "encryptionKey" "${KUBETAIL_DASHBOARD_SESSION_ENCRYPTION_KEY1}") }}
@@ -303,7 +378,9 @@ allowed-namespaces:
 {{- end }}
 addr: :{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
 {{- $cfg := omit .Values.kubetail.clusterAPI.runtimeConfig "ports" "http"}}
-{{- $_ := set $cfg "clusterAgent" ( dict "dispatchUrl" $dispatchUrl )}}
+{{- $clusterAgentCfg := deepCopy (default dict $cfg.clusterAgent) }}
+{{- $_ := set $clusterAgentCfg "dispatchUrl" $dispatchUrl }}
+{{- $_ := set $cfg "clusterAgent" $clusterAgentCfg }}
 {{- include "kubetail.toKebabYaml" $cfg | nindent 0 }}
 {{- end }}
 
@@ -380,6 +457,13 @@ Cluster API Secret data
 {{- if $currentResource -}}
 {{- $_ := set $currentValsRef "data" (index $currentResource "data") -}}
 {{- end -}}
+{{- end }}
+
+{{/*
+Cluster API TLS Secret name
+*/}}
+{{- define "kubetail.clusterAPI.tlsSecretName" -}}
+{{ include "kubetail.fullname" $ }}-cluster-api-tls
 {{- end }}
 
 {{/*
@@ -497,6 +581,13 @@ Cluster Agent RoleBinding name
 */}}
 {{- define "kubetail.clusterAgent.roleBindingName" -}}
 {{ if .Values.kubetail.clusterAgent.rbac.name }}{{ .Values.kubetail.clusterAgent.rbac.name }}{{ else }}{{ include "kubetail.fullname" $ }}-cluster-agent{{ end }}
+{{- end }}
+
+{{/*
+Cluster Agent TLS Secret name
+*/}}
+{{- define "kubetail.clusterAgent.tlsSecretName" -}}
+{{ include "kubetail.fullname" $ }}-cluster-agent-tls
 {{- end }}
 
 {{/*

--- a/charts/kubetail/templates/cluster-agent/daemon-set.yaml
+++ b/charts/kubetail/templates/cluster-agent/daemon-set.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         {{- include "kubetail.annotations" (list $ $podTmpl.annotations) | indent 8 }}
         checksum/config: {{ include "kubetail.clusterAgent.config" $ | sha256sum | quote }}
+        checksum/tls: {{ include "kubetail.tlsBundle" $ | sha256sum | quote }}
     spec:
       automountServiceAccountToken: true
       serviceAccountName: {{ include "kubetail.clusterAgent.serviceAccountName" $ }}
@@ -55,16 +56,17 @@ spec:
         - name: grpc
           protocol: TCP
           containerPort: {{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
+        # gRPC probes can't speak mTLS, so we fall back to a tcpSocket probe (port-open check).
         livenessProbe:
-          grpc:
-            port: {{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
+          tcpSocket:
+            port: grpc
           initialDelaySeconds: 5
           timeoutSeconds: 30
           periodSeconds: 3
           failureThreshold: 3
         readinessProbe:
-          grpc:
-            port: {{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
+          tcpSocket:
+            port: grpc
           initialDelaySeconds: 5
           timeoutSeconds: 30
           periodSeconds: 3
@@ -76,6 +78,9 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/kubetail
+          readOnly: true
+        - name: tls
+          mountPath: /etc/kubetail-tls
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -90,6 +95,9 @@ spec:
       - name: config
         configMap:
           name: {{ include "kubetail.clusterAgent.configMapName" $ }}
+      - name: tls
+        secret:
+          secretName: {{ include "kubetail.clusterAgent.tlsSecretName" $ }}
       - name: varlog
         hostPath:
           path: /var/log

--- a/charts/kubetail/templates/cluster-agent/rbac.yaml
+++ b/charts/kubetail/templates/cluster-agent/rbac.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.kubetail.clusterAgent.enabled }}
+{{- $rbac := index .Values "kubetail" "clusterAgent" "rbac" -}}
+# Lets the cluster-agent SA call SubjectAccessReview / TokenReview against the
+# kube-apiserver — the cluster-agent authenticates incoming gRPC clients via
+# mTLS and then delegates per-request authz to the kube-apiserver.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubetail.clusterAgent.clusterRoleBindingName" $ }}-auth-delegator
+  labels:
+    {{- include "kubetail.clusterAgent.labels" (list $ $rbac.labels) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubetail.clusterAgent.serviceAccountName" $ }}
+  namespace: {{ include "kubetail.namespace" $ }}
+{{- end }}

--- a/charts/kubetail/templates/cluster-agent/tls-secret.yaml
+++ b/charts/kubetail/templates/cluster-agent/tls-secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.kubetail.clusterAgent.enabled }}
+{{- $bundle := include "kubetail.tlsBundle" $ | fromYaml }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "kubetail.clusterAgent.tlsSecretName" $ }}
+  namespace: {{ include "kubetail.namespace" $ }}
+  labels:
+    {{- include "kubetail.clusterAgent.labels" (list $ dict) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ dict) | indent 4 }}
+type: Opaque
+data:
+  ca.crt: {{ $bundle.caCert | b64enc }}
+  tls.crt: {{ $bundle.agentCert | b64enc }}
+  tls.key: {{ $bundle.agentKey | b64enc }}
+{{- end }}

--- a/charts/kubetail/templates/cluster-api/api-service.yaml
+++ b/charts/kubetail/templates/cluster-api/api-service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.kubetail.clusterAPI.enabled }}
+{{- $bundle := include "kubetail.tlsBundle" $ | fromYaml }}
+# Register cluster-api with the kube-apiserver aggregation layer so that
+# requests to /apis/api.kubetail.com/v1/* are proxied to the cluster-api
+# Service. The dashboard relies on this both for its calls to cluster-api
+# and to surface cluster-api health via the APIService's Available condition.
+kind: APIService
+apiVersion: apiregistration.k8s.io/v1
+metadata:
+  name: v1.api.kubetail.com
+  labels:
+    {{- include "kubetail.clusterAPI.labels" (list $ dict) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ dict) | indent 4 }}
+spec:
+  group: api.kubetail.com
+  version: v1
+  groupPriorityMinimum: 100
+  versionPriority: 20
+  service:
+    name: {{ include "kubetail.clusterAPI.serviceName" $ }}
+    namespace: {{ include "kubetail.namespace" $ }}
+    port: {{ .Values.kubetail.clusterAPI.service.ports.http }}
+  # Embed the chart-generated CA so the kube-apiserver can verify the
+  # cluster-api server cert presented by the aggregation target.
+  caBundle: {{ $bundle.caCert | b64enc }}
+{{- end }}

--- a/charts/kubetail/templates/cluster-api/deployment.yaml
+++ b/charts/kubetail/templates/cluster-api/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         {{- include "kubetail.annotations" (list $ $podTmpl.annotations) | indent 8 }}
         checksum/config: {{ include "kubetail.clusterAPI.config" $ | sha256sum | quote }}
+        checksum/tls: {{ include "kubetail.tlsBundle" $ | sha256sum | quote }}
         {{- if $secret.enabled }}
         checksum/secret: {{ include "kubetail.clusterAPI.secretData" $ | sha256sum | quote }}
         {{- end }}
@@ -69,7 +70,7 @@ spec:
           containerPort: {{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
         livenessProbe:
           httpGet:
-            scheme: HTTP
+            scheme: HTTPS
             path: /healthz
             port: http
           initialDelaySeconds: 30
@@ -78,7 +79,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            scheme: HTTP
+            scheme: HTTPS
             path: /healthz
             port: http
           initialDelaySeconds: 30
@@ -93,6 +94,9 @@ spec:
         - name: config
           mountPath: /etc/kubetail
           readOnly: true
+        - name: tls
+          mountPath: /etc/kubetail-tls
+          readOnly: true
       {{- with $podTmpl.extraContainers  }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -100,6 +104,20 @@ spec:
       - name: config
         configMap:
           name: {{ include "kubetail.clusterAPI.configMapName" $ }}
+      - name: tls
+        secret:
+          secretName: {{ include "kubetail.clusterAPI.tlsSecretName" $ }}
+          items:
+          - key: ca.crt
+            path: ca.crt
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          - key: client.crt
+            path: client.crt
+          - key: client.key
+            path: client.key
       nodeSelector:
         {{- with $podTmpl.nodeSelector }}
         {{- toYaml . | nindent 8 }}

--- a/charts/kubetail/templates/cluster-api/rbac.yaml
+++ b/charts/kubetail/templates/cluster-api/rbac.yaml
@@ -43,6 +43,47 @@ subjects:
   namespace: {{ include "kubetail.namespace" $ }}
 {{- end }}
 ---
+# Lets the cluster-api SA call TokenReview / SubjectAccessReview against the
+# kube-apiserver — required for k8s-style delegated auth (the other half of
+# the auth-reader binding below).
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubetail.clusterAPI.clusterRoleBindingName" $ }}-auth-delegator
+  labels:
+    {{- include "kubetail.clusterAPI.labels" (list $ $rbac.labels) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubetail.clusterAPI.serviceAccountName" $ }}
+  namespace: {{ include "kubetail.namespace" $ }}
+---
+# Bind to the system-managed Role in kube-system so cluster-api can read the
+# `extension-apiserver-authentication` ConfigMap (required for k8s-style
+# delegated authentication: requestheader CA bundle, client CA, etc.).
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: {{ include "kubetail.clusterAPI.roleBindingName" $ }}-auth-reader
+  labels:
+    {{- include "kubetail.clusterAPI.labels" (list $ $rbac.labels) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubetail.clusterAPI.serviceAccountName" $ }}
+  namespace: {{ include "kubetail.namespace" $ }}
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -60,6 +101,16 @@ rules:
   resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
   verbs: [get, list, watch]
 {{- end }}
+# Lets cluster-api impersonate the calling user / SA when forwarding requests
+# downstream (e.g. dispatching to the cluster-agent). The aggregation layer
+# delivers the original caller's identity in headers; cluster-api then
+# performs the downstream call on their behalf.
+- apiGroups: [""]
+  resources: [users, groups, serviceaccounts]
+  verbs: [impersonate]
+- apiGroups: [authentication.k8s.io]
+  resources: ["*"]
+  verbs: [impersonate]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubetail/templates/cluster-api/tls-secret.yaml
+++ b/charts/kubetail/templates/cluster-api/tls-secret.yaml
@@ -19,4 +19,7 @@ data:
   tls.key: {{ $bundle.apiKey | b64enc }}
   client.crt: {{ $bundle.clientCert | b64enc }}
   client.key: {{ $bundle.clientKey | b64enc }}
+  # Unix epoch (seconds) when the leaf certs in this bundle expire. Read on
+  # subsequent renders to drive in-place renewal before the leaves go stale.
+  not-after: {{ $bundle.notAfter | b64enc }}
 {{- end }}

--- a/charts/kubetail/templates/cluster-api/tls-secret.yaml
+++ b/charts/kubetail/templates/cluster-api/tls-secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.kubetail.clusterAPI.enabled }}
+{{- $bundle := include "kubetail.tlsBundle" $ | fromYaml }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "kubetail.clusterAPI.tlsSecretName" $ }}
+  namespace: {{ include "kubetail.namespace" $ }}
+  labels:
+    {{- include "kubetail.clusterAPI.labels" (list $ dict) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ dict) | indent 4 }}
+type: Opaque
+data:
+  ca.crt: {{ $bundle.caCert | b64enc }}
+  # ca.key is stored here (not mounted into the agent) so the chart can
+  # re-sign leaf certs on `helm upgrade` without rotating the CA.
+  ca.key: {{ $bundle.caKey | b64enc }}
+  tls.crt: {{ $bundle.apiCert | b64enc }}
+  tls.key: {{ $bundle.apiKey | b64enc }}
+  client.crt: {{ $bundle.clientCert | b64enc }}
+  client.key: {{ $bundle.clientKey | b64enc }}
+{{- end }}

--- a/charts/kubetail/templates/dashboard/rbac.yaml
+++ b/charts/kubetail/templates/dashboard/rbac.yaml
@@ -26,6 +26,25 @@ rules:
   resources: [pods/log]
   verbs: [get]
 {{- end }}
+{{- if .Values.kubetail.clusterAPI.enabled }}
+# Watch the cluster-api APIService registration so the dashboard can surface
+# its health (Available condition).
+- apiGroups: [apiregistration.k8s.io]
+  resources: [apiservices]
+  verbs: [get, list, watch]
+# Talk to cluster-api through the kube-apiserver aggregation layer
+# (/apis/api.kubetail.com/v1). Used as a fallback when no user token is in
+# context (e.g. service-side health checks).
+- apiGroups: [api.kubetail.com]
+  resources: [graphql]
+  verbs: [get, list, create]
+- apiGroups: [api.kubetail.com]
+  resources: [download]
+  verbs: [create]
+- apiGroups: [api.kubetail.com]
+  resources: [healthz]
+  verbs: [get, list]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -282,8 +282,10 @@ kubetail:
           keyFile: /etc/kubetail-tls/client.key
           # -- Path to CA bundle used to verify the agent's server cert
           caFile: /etc/kubetail-tls/ca.crt
-          # -- Expected SNI / SAN of the agent's server cert
-          serverName: kubetail-cluster-agent
+          # -- Expected SNI / SAN of the agent's server cert.
+          # When null (default), derived from the cluster-agent service name so
+          # it matches the cert SANs the chart generates.
+          serverName: null
 
     # -- Docker image settings
     image:

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -107,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.14.0"
+      tag: "0.15.0-rc2"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -265,14 +265,25 @@ kubetail:
           enabled: true
           # -- Hides health checks from access log
           hideHealthChecks: true
-      # -- TLS options
+      # -- Server-side TLS options (TLS is mandatory).
+      # The chart provisions cert/key automatically; the paths below are where
+      # they are mounted inside the container.
       tls:
-        # -- Enables/disables TLS termination
-        enabled: false
         # -- Path to TLS certificate file
-        certFile: null
+        certFile: /etc/kubetail-tls/tls.crt
         # -- Path to TLS key file
-        keyFile: null
+        keyFile: /etc/kubetail-tls/tls.key
+      # -- Outbound mTLS settings used when dispatching to the Cluster Agent.
+      clusterAgent:
+        tls:
+          # -- Path to client certificate
+          certFile: /etc/kubetail-tls/client.crt
+          # -- Path to client key
+          keyFile: /etc/kubetail-tls/client.key
+          # -- Path to CA bundle used to verify the agent's server cert
+          caFile: /etc/kubetail-tls/ca.crt
+          # -- Expected SNI / SAN of the agent's server cert
+          serverName: kubetail-cluster-agent
 
     # -- Docker image settings
     image:
@@ -281,7 +292,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.7.0"
+      tag: "0.8.0-rc2"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -412,14 +423,19 @@ kubetail:
         level: "info"
         # -- Sets the logging format (json, pretty)
         format: "json"
-      # -- TLS options
+      # -- TLS options (TLS is mandatory; mTLS is enforced).
+      # The chart provisions cert/key/ca automatically; paths below are where
+      # they are mounted inside the container.
       tls:
-        # -- Enables/disables TLS termination
-        enabled: false
         # -- Path to TLS certificate file
-        certFile: null
+        certFile: /etc/kubetail-tls/tls.crt
         # -- Path to TLS key file
-        keyFile: null
+        keyFile: /etc/kubetail-tls/tls.key
+        # -- Path to CA bundle used to verify incoming client certs
+        caFile: /etc/kubetail-tls/ca.crt
+        # -- Allow-list of client cert CN/SAN values; only these may dial the agent
+        allowedNames:
+        - kubetail-cluster-api
 
     # -- Docker image settings
     image:
@@ -428,7 +444,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-agent"
       # -- Image tag
-      tag: "0.6.2"
+      tag: "0.7.0-rc1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -505,6 +521,15 @@ kubetail:
       # -- Enable resource
       enabled: true
       # -- Overrides the NetworkPolicy resource name whose default is based on the chart's computed fullname
+      name: null
+      # -- Additional annotations
+      annotations: {}
+      # -- Additional labels
+      labels: {}
+
+    # -- RBAC resource settings
+    rbac:
+      # -- Overrides RBAC resource names whose defaults are based on the chart's computed fullname
       name: null
       # -- Additional annotations
       annotations: {}


### PR DESCRIPTION
## Summary

Bumps the bundled kubetail components to their 0.24.x release candidates: dashboard `0.15.0-rc2`, cluster-api `0.8.0-rc2`, and cluster-agent `0.7.0-rc1`. These releases make TLS mandatory for cluster-api, mTLS mandatory for cluster-agent, and move cluster-api behind the Kubernetes API server aggregation layer — none of which the chart previously supported. This PR adds the cert provisioning, RBAC, and APIService wiring needed to keep the chart working out of the box on the new versions.

## Key Changes

- Generate a self-signed CA plus server/client leaf certs in templates, cached on `.Values` and recovered via `lookup` so certs stay stable across `helm upgrade`. New TLS Secrets are mounted on cluster-api and cluster-agent at `/etc/kubetail-tls/`.
- Drop `tls.enabled` from runtime config (now an error in cluster-api 0.8) and emit `cert-file` / `key-file` / `ca-file` paths unconditionally. Add `clusterAPI.runtimeConfig.clusterAgent.tls` for mTLS dispatch and `clusterAgent.runtimeConfig.tls.allowedNames` (defaults to `["kubetail-cluster-api"]`).
- Register cluster-api as `APIService v1.api.kubetail.com` with the chart-generated CA in `caBundle` so the kube-apiserver can verify the aggregated target.
- Add the RBAC the new architecture requires:
  - **Dashboard** can watch `apiservices` (for cluster-api health) and call the `api.kubetail.com` aggregated resources (`graphql`, `download`, `healthz`).
  - **Cluster-api** binds to `system:auth-delegator` and the kube-system `extension-apiserver-authentication-reader` Role, and gets impersonate permissions on users / groups / serviceaccounts / `authentication.k8s.io/*`.
  - **Cluster-agent** binds to `system:auth-delegator`.
- Switch cluster-api liveness/readiness probes to `HTTPS`. Replace cluster-agent gRPC probes with `tcpSocket` (gRPC probes can't speak mTLS).
- Drop the dashboard's removed `cluster-api-endpoint` config and move `ui.cluster-api-enabled` to the new top-level `cluster-api-enabled` field.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused