### PR TITLE
🐋 Bump kubetail to 0.24.0

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.24.0-rc2
-appVersion: "0.23.0-rc1"
+version: 0.24.0
+appVersion: "0.23.0"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -107,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.15.0-rc2"
+      tag: "0.15.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -294,7 +294,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.8.0-rc2"
+      tag: "0.8.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -446,7 +446,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-agent"
       # -- Image tag
-      tag: "0.7.0-rc1"
+      tag: "0.7.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Promotes the 0.24.0 release candidate to a final release. Removes `-rc` suffixes from the chart version, appVersion, and component image tags.

## Key Changes

- Bump chart version to 0.24.0 and appVersion to 0.23.0
- Bump dashboard image tag to 0.15.0
- Bump cluster-api image tag to 0.8.0
- Bump cluster-agent image tag to 0.7.0

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused