### PR TITLE
📜 Use kubetail namespace in install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Next install/upgrade/uninstall:
 helm install kubetail kubetail/kubetail
 
 # install into a new namespace
-helm install kubetail kubetail/kubetail --namespace kubetail-system --create-namespace
+helm install kubetail kubetail/kubetail --namespace kubetail --create-namespace
 
 # install using custom values
-helm install kubetail kubetail/kubetail --namespace kubetail-system --create-namespace --values ~/path/to/values.yaml
+helm install kubetail kubetail/kubetail --namespace kubetail --create-namespace --values ~/path/to/values.yaml
 
 # upgrade an existing installation
-helm upgrade kubetail kubetail/kubetail --namespace kubetail-system
+helm upgrade kubetail kubetail/kubetail --namespace kubetail
 
 # uninstall
-helm uninstall kubetail --namespace kubetail-system
+helm uninstall kubetail --namespace kubetail
 ```

--- a/hack/kubetail-values-clusterauth.yaml
+++ b/hack/kubetail-values-clusterauth.yaml
@@ -1,4 +1,4 @@
-namespaceOverride: kubetail-system
+namespaceOverride: kubetail
 
 kubetail:
   secrets:

--- a/hack/kubetail-values-tokenauth.yaml
+++ b/hack/kubetail-values-tokenauth.yaml
@@ -1,4 +1,4 @@
-namespaceOverride: kubetail-system
+namespaceOverride: kubetail
 
 kubetail:
   secrets:


### PR DESCRIPTION
## Summary

The README and hack values files referenced a `kubetail-system` namespace, but the project's documented convention is to install into a namespace named `kubetail`. This aligns the example commands and local test values with that convention so users copy-pasting from the README land in the expected namespace.

## Key Changes

- Update README install/upgrade/uninstall examples to use `--namespace kubetail`.
- Update `hack/kubetail-values-clusterauth.yaml` and `hack/kubetail-values-tokenauth.yaml` to set `namespaceOverride: kubetail`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused