### PR TITLE
✨ Bump kubetail to 0.25.0-rc1

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.24.0
-appVersion: "0.23.0"
+version: 0.25.0-rc1
+appVersion: "0.24.0-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/templates/cluster-agent/rbac.yaml
+++ b/charts/kubetail/templates/cluster-agent/rbac.yaml
@@ -1,12 +1,27 @@
 {{- if .Values.kubetail.clusterAgent.enabled }}
 {{- $rbac := index .Values "kubetail" "clusterAgent" "rbac" -}}
-# Lets the cluster-agent SA call SubjectAccessReview / TokenReview against the
-# kube-apiserver — the cluster-agent authenticates incoming gRPC clients via
-# mTLS and then delegates per-request authz to the kube-apiserver.
+# The cluster-agent authenticates incoming gRPC clients via mTLS (identity
+# forwarded from cluster-api) and then delegates per-request authz to the
+# kube-apiserver by asking whether the forwarded user can `get pods/log` in
+# the requested namespace. SubjectAccessReview is the only API access it needs
+# — logs are read directly from the node's container-logs directory on disk.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubetail.clusterAgent.clusterRoleName" $ }}
+  labels:
+    {{- include "kubetail.clusterAgent.labels" (list $ $rbac.labels) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
+rules:
+- apiGroups: [authorization.k8s.io]
+  resources: [subjectaccessreviews]
+  verbs: [create]
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kubetail.clusterAgent.clusterRoleBindingName" $ }}-auth-delegator
+  name: {{ include "kubetail.clusterAgent.clusterRoleBindingName" $ }}
   labels:
     {{- include "kubetail.clusterAgent.labels" (list $ $rbac.labels) | indent 4 }}
   annotations:
@@ -14,7 +29,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:auth-delegator
+  name: {{ include "kubetail.clusterAgent.clusterRoleName" $ }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.clusterAgent.serviceAccountName" $ }}

--- a/charts/kubetail/templates/cluster-api/rbac.yaml
+++ b/charts/kubetail/templates/cluster-api/rbac.yaml
@@ -1,33 +1,24 @@
 {{- if .Values.kubetail.clusterAPI.enabled }}
 {{- $rbac := index .Values "kubetail" "clusterAPI" "rbac" -}}
-{{- $root := . -}}
-{{- range $namespace := uniq (append .Values.kubetail.allowedNamespaces (include "kubetail.namespace" $)) }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: {{ $namespace }}
+  namespace: {{ include "kubetail.namespace" $ }}
   name: {{ include "kubetail.clusterAPI.roleName" $ }}
   labels:
     {{- include "kubetail.clusterAPI.labels" (list $ $rbac.labels) | indent 4 }}
   annotations:
     {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
 rules:
-{{- if eq $namespace (include "kubetail.namespace" $) }}
 - apiGroups: [discovery.k8s.io]
   resources: [endpointslices]
   verbs: [list, watch]
-{{- end }}
-{{- if has $namespace $root.Values.kubetail.allowedNamespaces }}
-- apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
-  verbs: [get, list, watch]
-{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: {{ $namespace }}
+  namespace: {{ include "kubetail.namespace" $ }}
   name: {{ include "kubetail.clusterAPI.roleBindingName" $ }}
   labels:
     {{- include "kubetail.clusterAPI.labels" (list $ $rbac.labels) | indent 4 }}
@@ -41,7 +32,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.clusterAPI.serviceAccountName" $ }}
   namespace: {{ include "kubetail.namespace" $ }}
-{{- end }}
 ---
 # Lets the cluster-api SA call TokenReview / SubjectAccessReview against the
 # kube-apiserver — required for k8s-style delegated auth (the other half of
@@ -96,11 +86,13 @@ rules:
 - apiGroups: [""]
   resources: [nodes]
   verbs: [get, list, watch]
-{{- if not .Values.kubetail.allowedNamespaces }}
+# Workload + pod informers in modules/shared/logs (sourceWatcher) — used to
+# resolve log sources to pods. Cluster-wide so the API can serve logs across
+# all namespaces. Note: no pods/log; pod logs are streamed from the
+# cluster-agent over gRPC, not read via the Kubernetes API.
 - apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
+  resources: [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
   verbs: [get, list, watch]
-{{- end }}
 # Lets cluster-api impersonate the calling user / SA when forwarding requests
 # downstream (e.g. dispatching to the cluster-agent). The aggregation layer
 # delivers the original caller's identity in headers; cluster-api then

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -107,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.15.0"
+      tag: "0.16.0-rc1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Release candidate for kubetail 0.25.0. Bumps chart and image versions and tightens RBAC to match the new auth model, where pod logs are streamed from the cluster-agent over gRPC rather than read through the Kubernetes API.

## Key Changes

- Bump chart version to `0.25.0-rc1`, appVersion to `0.24.0-rc1`, and dashboard image to `0.16.0-rc1`.
- Give the cluster-agent a dedicated ClusterRole granting only `subjectaccessreviews/create` instead of binding to the built-in `system:auth-delegator` role.
- Collapse the cluster-api Role to the release namespace, dropping the per-allowed-namespace Role/RoleBinding loop and removing `pods/log` and per-namespace workload access — the cluster-api no longer reads pod logs via the Kubernetes API.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused