### PR TITLE
✨ Bump kubetail to 0.25.0-rc2 and simplify allowed-namespaces RBAC

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.0-rc1
-appVersion: "0.24.0-rc1"
+version: 0.25.0-rc2
+appVersion: "0.24.0-rc2"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -404,10 +404,6 @@ Cluster API config
 {{- $agentSvc := include "kubetail.clusterAgent.serviceName" $ }}
 {{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $dispatchUrl := printf "kubernetes://%s:%d" $agentSvc $dispatchUrlPort }}
-{{- with .Values.kubetail.allowedNamespaces }}
-allowed-namespaces:
-{{- toYaml . | nindent 0 }}
-{{- end }}
 addr: :{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
 {{- $cfg := omit .Values.kubetail.clusterAPI.runtimeConfig "ports" "http"}}
 {{- $clusterAgentCfg := deepCopy (default dict $cfg.clusterAgent) }}
@@ -544,11 +540,7 @@ app.kubernetes.io/component: "cluster-agent"
 {{/*
 Cluster Agent config
 */}}
-{{- define "kubetail.clusterAgent.config" -}}
-{{- with .Values.kubetail.allowedNamespaces }}
-allowed-namespaces: 
-{{- toYaml . | nindent 0 }}
-{{- end }}
+{{- define "kubetail.clusterAgent.config" }}
 addr: :{{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $cfg := omit .Values.kubetail.clusterAgent.runtimeConfig "ports" "grpc" }}
 {{- include "kubetail.toKebabYaml" $cfg | nindent 0 }}

--- a/charts/kubetail/templates/dashboard/rbac.yaml
+++ b/charts/kubetail/templates/dashboard/rbac.yaml
@@ -21,7 +21,7 @@ rules:
 - apiGroups: [authentication.k8s.io]
   resources: [tokenreviews]
   verbs: [create]
-{{- else }}
+{{- else if not .Values.kubetail.allowedNamespaces }}
 - apiGroups: [""]
   resources: [pods/log]
   verbs: [get]
@@ -62,79 +62,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
   namespace: {{ include "kubetail.namespace" $ }}
-{{- if or (eq .Values.kubetail.dashboard.authMode "token") (not .Values.kubetail.allowedNamespaces) }}
-{{- if .Values.kubetail.clusterAPI.enabled }}
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-rules:
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleBindingName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
-  namespace: {{ include "kubetail.namespace" $ }}
-{{- end }}
-{{- end }}
 {{- if and (ne .Values.kubetail.dashboard.authMode "token") (.Values.kubetail.allowedNamespaces) }}
-{{- if not (has (include "kubetail.namespace" $) .Values.kubetail.allowedNamespaces) }}
-{{- if .Values.kubetail.clusterAPI.enabled }}
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-rules:
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleBindingName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
-  namespace: {{ include "kubetail.namespace" $ }}
-{{- end }}
-{{- end }}
 {{- range .Values.kubetail.allowedNamespaces }}
 ---
 kind: Role
@@ -150,11 +78,6 @@ rules:
 - apiGroups: ["", apps, batch]
   resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
   verbs: [get, list, watch]
-{{- if eq . (include "kubetail.namespace" $) }}
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
-{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

Bumps the chart to 0.25.0-rc2 (appVersion 0.24.0-rc2) and simplifies how
allowed namespaces are handled. The cluster-api and cluster-agent no longer
receive an `allowed-namespaces` config block, and the dashboard RBAC is
trimmed so it only grants the broad cluster-wide `pods/log` permission when
no allowed namespaces are configured, while the redundant per-namespace
endpointslices Role/RoleBinding pairs are removed.

## Key Changes

- Bump chart version to `0.25.0-rc2` and appVersion to `0.24.0-rc2`.
- Remove the `allowed-namespaces` block from the cluster-api and
  cluster-agent runtime configs in `_helpers.tpl`.
- Gate the dashboard's cluster-wide `pods/log` rule on
  `not .Values.kubetail.allowedNamespaces`.
- Drop the dashboard endpointslices `Role`/`RoleBinding` (both the
  token-auth and allowed-namespaces variants) and the per-namespace
  endpointslices rule.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused