### PR TITLE
🐋 Propagate allowedNamespaces to cluster-api and cluster-agent config

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.0-rc2
-appVersion: "0.24.0-rc2"
+version: 0.25.0-rc3
+appVersion: "0.24.0-rc3"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -404,6 +404,10 @@ Cluster API config
 {{- $agentSvc := include "kubetail.clusterAgent.serviceName" $ }}
 {{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $dispatchUrl := printf "kubernetes://%s:%d" $agentSvc $dispatchUrlPort }}
+{{- with .Values.kubetail.allowedNamespaces }}
+allowed-namespaces:
+{{- toYaml . | nindent 0 }}
+{{- end }}
 addr: :{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
 {{- $cfg := omit .Values.kubetail.clusterAPI.runtimeConfig "ports" "http"}}
 {{- $clusterAgentCfg := deepCopy (default dict $cfg.clusterAgent) }}
@@ -540,7 +544,11 @@ app.kubernetes.io/component: "cluster-agent"
 {{/*
 Cluster Agent config
 */}}
-{{- define "kubetail.clusterAgent.config" }}
+{{- define "kubetail.clusterAgent.config" -}}
+{{- with .Values.kubetail.allowedNamespaces }}
+allowed-namespaces:
+{{- toYaml . | nindent 0 }}
+{{- end }}
 addr: :{{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $cfg := omit .Values.kubetail.clusterAgent.runtimeConfig "ports" "grpc" }}
 {{- include "kubetail.toKebabYaml" $cfg | nindent 0 }}


### PR DESCRIPTION
## Summary

The `kubetail.allowedNamespaces` value was not being passed through to the
cluster-api and cluster-agent runtime config, so namespace restrictions were
not enforced by those components. This propagates the value into both configs
and ships it as the `0.25.0-rc3` release candidate.

## Key Changes

- Render `allowed-namespaces` from `kubetail.allowedNamespaces` in the
  cluster-api config helper
- Render `allowed-namespaces` from `kubetail.allowedNamespaces` in the
  cluster-agent config helper, and trim leading whitespace from the
  `kubetail.clusterAgent.config` define
- Bump chart `version` to `0.25.0-rc3` and `appVersion` to `0.24.0-rc3`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused