### PR TITLE
🐋 Bump kubetail to 0.25.0

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.24.0
-appVersion: "0.23.0"
+version: 0.25.0
+appVersion: "0.24.0"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -107,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.15.0"
+      tag: "0.16.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -294,7 +294,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.8.0"
+      tag: "0.8.1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy
@@ -446,7 +446,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-agent"
       # -- Image tag
-      tag: "0.7.0"
+      tag: "0.7.1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Bumps the kubetail chart to 0.25.0, pulling in the latest dashboard, cluster-api, and cluster-agent releases. No runtime config changes were required — all upstream config diffs were either empty or limited to internal refactors.

## Key Changes

- Bump dashboard image to 0.16.0
- Bump cluster-api image to 0.8.1
- Bump cluster-agent image to 0.7.1
- Bump chart `version` to 0.25.0 and `appVersion` to 0.24.0

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused