### PR TITLE
🐋 Bump kubetail to 0.25.1

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.0
-appVersion: "0.24.0"
+version: 0.25.1
+appVersion: "0.24.1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -107,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.16.0"
+      tag: "0.16.1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Bumps the kubetail dashboard image to v0.16.1 and updates the chart version/appVersion accordingly. No config changes were required.

## Key Changes

- Bump `kubetail.dashboard.image.tag` from `0.16.0` to `0.16.1`
- Bump chart `version` from `0.25.0` to `0.25.1`
- Bump chart `appVersion` from `0.24.0` to `0.24.1`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused