### PR TITLE
🐋 Add dashboard allowedNamespace option and deprecate allowedNamespaces

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.0-rc3
-appVersion: "0.24.0-rc3"
+version: 0.26.0-rc1
+appVersion: "0.25.0-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/README.md
+++ b/charts/kubetail/README.md
@@ -57,7 +57,7 @@ These are the configurable parameters for the kubetail chart and their default v
 | `namespaceOverride`                                   | string   | Override release's namespace          | null                            |
 |                                                       |          |                                       |                                 |
 | KUBETAIL GENERAL:                                     |          |                                       |                                 |
-| `kubetail.allowedNamespaces`                          | array    | Restricted namespaces                 | []                              |
+| `kubetail.allowedNamespaces`                          | array    | Restricted namespaces (DEPRECATED)    | []                              |
 | `kubetail.global.annotations`                         | map      | Annotations for all resources         | {}                              |
 | `kubetail.global.labels`                              | map      | Labels for all resources              | {}                              |
 | `kubetail.secrets.KUBETAIL_DASHBOARD_SESSION_SIGNING_KEY1`    | string   | B64-encoded value (autogen if null)   | null                            |
@@ -65,6 +65,7 @@ These are the configurable parameters for the kubetail chart and their default v
 |                                                       |          |                                       |                                 |
 | KUBETAIL DASHBOARD:                                   |          |                                       |                                 |
 | `kubetail.dashboard.enabled`                          | bool     | Enable/disable dashboard              | true                            |
+| `kubetail.dashboard.allowedNamespace`                 | string   | Restrict Kubetail to a single namespace | null                          |
 | `kubetail.dashboard.authMode`                         | string   | Auth mode (auto, token)               | "auto"                          |
 | `kubetail.dashboard.runtimeConfig`                    | map      | Dashboard runtime configuration       | *See values.yaml*               |
 | `kubetail.dashboard.image.registry`                   | string   | Dashboard image registry              | ghcr.io                         |

--- a/charts/kubetail/templates/NOTES.txt
+++ b/charts/kubetail/templates/NOTES.txt
@@ -1,0 +1,4 @@
+{{- if .Values.kubetail.allowedNamespaces }}
+WARNING: `kubetail.allowedNamespaces` is deprecated and will be removed in the
+next version. Use `kubetail.dashboard.allowedNamespace` instead.
+{{- end }}

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -241,11 +241,24 @@ app.kubernetes.io/component: "dashboard"
 {{- end }}
 
 {{/*
+Resolve the effective list of allowed namespaces.
+Merges the deprecated `kubetail.allowedNamespaces` list with the new
+single-value `kubetail.dashboard.allowedNamespace` option.
+*/}}
+{{- define "kubetail.allowedNamespaces" -}}
+{{- $namespaces := .Values.kubetail.allowedNamespaces | default list -}}
+{{- with .Values.kubetail.dashboard.allowedNamespace -}}
+{{- $namespaces = concat $namespaces (list .) -}}
+{{- end -}}
+{{- $namespaces | uniq | toYaml -}}
+{{- end -}}
+
+{{/*
 Dashboard config
 */}}
 {{- define "kubetail.dashboard.config" -}}
-{{- with .Values.kubetail.allowedNamespaces }}
-allowed-namespaces: 
+{{- with (include "kubetail.allowedNamespaces" $ | fromYamlArray) }}
+allowed-namespaces:
 {{- toYaml . | nindent 0 }}
 {{- end }}
 addr: :{{ .Values.kubetail.dashboard.runtimeConfig.ports.http }}
@@ -404,7 +417,7 @@ Cluster API config
 {{- $agentSvc := include "kubetail.clusterAgent.serviceName" $ }}
 {{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $dispatchUrl := printf "kubernetes://%s:%d" $agentSvc $dispatchUrlPort }}
-{{- with .Values.kubetail.allowedNamespaces }}
+{{- with (include "kubetail.allowedNamespaces" $ | fromYamlArray) }}
 allowed-namespaces:
 {{- toYaml . | nindent 0 }}
 {{- end }}
@@ -545,7 +558,7 @@ app.kubernetes.io/component: "cluster-agent"
 Cluster Agent config
 */}}
 {{- define "kubetail.clusterAgent.config" -}}
-{{- with .Values.kubetail.allowedNamespaces }}
+{{- with (include "kubetail.allowedNamespaces" $ | fromYamlArray) }}
 allowed-namespaces:
 {{- toYaml . | nindent 0 }}
 {{- end }}

--- a/charts/kubetail/templates/dashboard/rbac.yaml
+++ b/charts/kubetail/templates/dashboard/rbac.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.kubetail.dashboard.enabled }}
 {{- $rbac := index .Values "kubetail" "dashboard" "rbac" -}}
+{{- $allowedNamespaces := include "kubetail.allowedNamespaces" $ | fromYamlArray -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,7 +13,7 @@ rules:
 - apiGroups: [""]
   resources: [namespaces, nodes]
   verbs: [get, list, watch]
-{{- if not .Values.kubetail.allowedNamespaces }}
+{{- if not $allowedNamespaces }}
 - apiGroups: ["", apps, batch]
   resources: [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
   verbs: [get, list, watch]
@@ -21,7 +22,7 @@ rules:
 - apiGroups: [authentication.k8s.io]
   resources: [tokenreviews]
   verbs: [create]
-{{- else if not .Values.kubetail.allowedNamespaces }}
+{{- else if not $allowedNamespaces }}
 - apiGroups: [""]
   resources: [pods/log]
   verbs: [get]
@@ -62,8 +63,8 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
   namespace: {{ include "kubetail.namespace" $ }}
-{{- if and (ne .Values.kubetail.dashboard.authMode "token") (.Values.kubetail.allowedNamespaces) }}
-{{- range .Values.kubetail.allowedNamespaces }}
+{{- if and (ne .Values.kubetail.dashboard.authMode "token") ($allowedNamespaces) }}
+{{- range $allowedNamespaces }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -18,7 +18,8 @@ namespaceOverride: null
 # ###########################################################################################
 
 kubetail:
-  # --- Restrict namespaces
+  # -- DEPRECATED: use `kubetail.dashboard.allowedNamespace` instead.
+  # This option will be removed in the next version.
   allowedNamespaces: []
 
   # -- Define secrets
@@ -44,6 +45,8 @@ kubetail:
   dashboard:
     # -- Enable/disable dashboard
     enabled: true
+    # -- Restrict Kubetail to a single namespace
+    allowedNamespace: null
     # -- Sets the auth mode
     authMode: auto
 
@@ -107,7 +110,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.16.0-rc1"
+      tag: "0.17.0-rc1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Adds a single-value `kubetail.dashboard.allowedNamespace` option to restrict
Kubetail to one namespace, and deprecates the existing list-valued
`kubetail.allowedNamespaces`. The two are merged during rendering so existing
configurations continue to work unchanged, and users are warned at install time
when the deprecated option is still set.

## Key Changes

- Add `kubetail.dashboard.allowedNamespace` (string, default `null`) in `values.yaml`.
- Add a `kubetail.allowedNamespaces` helper that merges the deprecated list with
  the new single-value option (deduped) and is now used by the dashboard,
  cluster-api, and cluster-agent configs plus the dashboard RBAC templates.
- Add `NOTES.txt` warning when the deprecated `kubetail.allowedNamespaces` is set.
- Mark `kubetail.allowedNamespaces` as deprecated in `values.yaml` and `README.md`.
- Bump chart to `0.26.0-rc1`, appVersion to `0.25.0-rc1`, and dashboard image to `0.17.0-rc1`.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused