### PR TITLE
🐋 Bump kubetail to 0.25.0-rc2

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.26.0-rc1
-appVersion: "0.25.0-rc1"
+version: 0.26.0-rc2
+appVersion: "0.25.0-rc2"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -110,7 +110,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.17.0-rc1"
+      tag: "0.17.0-rc2"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Bumps the Kubetail dashboard to the `0.25.0-rc2` release candidate so the chart tracks the latest upstream pre-release.

## Key Changes

- Bump chart `version` to `0.26.0-rc2`
- Bump `appVersion` to `0.25.0-rc2`
- Bump dashboard image `tag` to `0.17.0-rc2`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused