### PR TITLE
Release/0.26.0

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.26.0-rc1
-appVersion: "0.25.0-rc1"
+version: 0.26.0-rc2
+appVersion: "0.25.0-rc2"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.0-rc2
-appVersion: "0.24.0-rc2"
+version: 0.25.0-rc3
+appVersion: "0.24.0-rc3"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.0-rc3
-appVersion: "0.24.0-rc3"
+version: 0.26.0-rc1
+appVersion: "0.25.0-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.1
-appVersion: "0.24.1"
+version: 0.25.0-rc1
+appVersion: "0.24.0-rc1"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.25.0-rc1
-appVersion: "0.24.0-rc1"
+version: 0.25.0-rc2
+appVersion: "0.24.0-rc2"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/README.md
+++ b/charts/kubetail/README.md
@@ -57,7 +57,7 @@ These are the configurable parameters for the kubetail chart and their default v
 | `namespaceOverride`                                   | string   | Override release's namespace          | null                            |
 |                                                       |          |                                       |                                 |
 | KUBETAIL GENERAL:                                     |          |                                       |                                 |
-| `kubetail.allowedNamespaces`                          | array    | Restricted namespaces                 | []                              |
+| `kubetail.allowedNamespaces`                          | array    | Restricted namespaces (DEPRECATED)    | []                              |
 | `kubetail.global.annotations`                         | map      | Annotations for all resources         | {}                              |
 | `kubetail.global.labels`                              | map      | Labels for all resources              | {}                              |
 | `kubetail.secrets.KUBETAIL_DASHBOARD_SESSION_SIGNING_KEY1`    | string   | B64-encoded value (autogen if null)   | null                            |
@@ -65,6 +65,7 @@ These are the configurable parameters for the kubetail chart and their default v
 |                                                       |          |                                       |                                 |
 | KUBETAIL DASHBOARD:                                   |          |                                       |                                 |
 | `kubetail.dashboard.enabled`                          | bool     | Enable/disable dashboard              | true                            |
+| `kubetail.dashboard.allowedNamespace`                 | string   | Restrict Kubetail to a single namespace | null                          |
 | `kubetail.dashboard.authMode`                         | string   | Auth mode (auto, token)               | "auto"                          |
 | `kubetail.dashboard.runtimeConfig`                    | map      | Dashboard runtime configuration       | *See values.yaml*               |
 | `kubetail.dashboard.image.registry`                   | string   | Dashboard image registry              | ghcr.io                         |

--- a/charts/kubetail/templates/NOTES.txt
+++ b/charts/kubetail/templates/NOTES.txt
@@ -1,0 +1,4 @@
+{{- if .Values.kubetail.allowedNamespaces }}
+WARNING: `kubetail.allowedNamespaces` is deprecated and will be removed in the
+next version. Use `kubetail.dashboard.allowedNamespace` instead.
+{{- end }}

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -404,6 +404,10 @@ Cluster API config
 {{- $agentSvc := include "kubetail.clusterAgent.serviceName" $ }}
 {{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $dispatchUrl := printf "kubernetes://%s:%d" $agentSvc $dispatchUrlPort }}
+{{- with .Values.kubetail.allowedNamespaces }}
+allowed-namespaces:
+{{- toYaml . | nindent 0 }}
+{{- end }}
 addr: :{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
 {{- $cfg := omit .Values.kubetail.clusterAPI.runtimeConfig "ports" "http"}}
 {{- $clusterAgentCfg := deepCopy (default dict $cfg.clusterAgent) }}
@@ -540,7 +544,11 @@ app.kubernetes.io/component: "cluster-agent"
 {{/*
 Cluster Agent config
 */}}
-{{- define "kubetail.clusterAgent.config" }}
+{{- define "kubetail.clusterAgent.config" -}}
+{{- with .Values.kubetail.allowedNamespaces }}
+allowed-namespaces:
+{{- toYaml . | nindent 0 }}
+{{- end }}
 addr: :{{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $cfg := omit .Values.kubetail.clusterAgent.runtimeConfig "ports" "grpc" }}
 {{- include "kubetail.toKebabYaml" $cfg | nindent 0 }}

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -404,10 +404,6 @@ Cluster API config
 {{- $agentSvc := include "kubetail.clusterAgent.serviceName" $ }}
 {{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $dispatchUrl := printf "kubernetes://%s:%d" $agentSvc $dispatchUrlPort }}
-{{- with .Values.kubetail.allowedNamespaces }}
-allowed-namespaces:
-{{- toYaml . | nindent 0 }}
-{{- end }}
 addr: :{{ .Values.kubetail.clusterAPI.runtimeConfig.ports.http }}
 {{- $cfg := omit .Values.kubetail.clusterAPI.runtimeConfig "ports" "http"}}
 {{- $clusterAgentCfg := deepCopy (default dict $cfg.clusterAgent) }}
@@ -544,11 +540,7 @@ app.kubernetes.io/component: "cluster-agent"
 {{/*
 Cluster Agent config
 */}}
-{{- define "kubetail.clusterAgent.config" -}}
-{{- with .Values.kubetail.allowedNamespaces }}
-allowed-namespaces: 
-{{- toYaml . | nindent 0 }}
-{{- end }}
+{{- define "kubetail.clusterAgent.config" }}
 addr: :{{ .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $cfg := omit .Values.kubetail.clusterAgent.runtimeConfig "ports" "grpc" }}
 {{- include "kubetail.toKebabYaml" $cfg | nindent 0 }}

--- a/charts/kubetail/templates/_helpers.tpl
+++ b/charts/kubetail/templates/_helpers.tpl
@@ -241,11 +241,24 @@ app.kubernetes.io/component: "dashboard"
 {{- end }}
 
 {{/*
+Resolve the effective list of allowed namespaces.
+Merges the deprecated `kubetail.allowedNamespaces` list with the new
+single-value `kubetail.dashboard.allowedNamespace` option.
+*/}}
+{{- define "kubetail.allowedNamespaces" -}}
+{{- $namespaces := .Values.kubetail.allowedNamespaces | default list -}}
+{{- with .Values.kubetail.dashboard.allowedNamespace -}}
+{{- $namespaces = concat $namespaces (list .) -}}
+{{- end -}}
+{{- $namespaces | uniq | toYaml -}}
+{{- end -}}
+
+{{/*
 Dashboard config
 */}}
 {{- define "kubetail.dashboard.config" -}}
-{{- with .Values.kubetail.allowedNamespaces }}
-allowed-namespaces: 
+{{- with (include "kubetail.allowedNamespaces" $ | fromYamlArray) }}
+allowed-namespaces:
 {{- toYaml . | nindent 0 }}
 {{- end }}
 addr: :{{ .Values.kubetail.dashboard.runtimeConfig.ports.http }}
@@ -404,7 +417,7 @@ Cluster API config
 {{- $agentSvc := include "kubetail.clusterAgent.serviceName" $ }}
 {{- $dispatchUrlPort := int .Values.kubetail.clusterAgent.runtimeConfig.ports.grpc }}
 {{- $dispatchUrl := printf "kubernetes://%s:%d" $agentSvc $dispatchUrlPort }}
-{{- with .Values.kubetail.allowedNamespaces }}
+{{- with (include "kubetail.allowedNamespaces" $ | fromYamlArray) }}
 allowed-namespaces:
 {{- toYaml . | nindent 0 }}
 {{- end }}
@@ -545,7 +558,7 @@ app.kubernetes.io/component: "cluster-agent"
 Cluster Agent config
 */}}
 {{- define "kubetail.clusterAgent.config" -}}
-{{- with .Values.kubetail.allowedNamespaces }}
+{{- with (include "kubetail.allowedNamespaces" $ | fromYamlArray) }}
 allowed-namespaces:
 {{- toYaml . | nindent 0 }}
 {{- end }}

--- a/charts/kubetail/templates/cluster-agent/rbac.yaml
+++ b/charts/kubetail/templates/cluster-agent/rbac.yaml
@@ -1,12 +1,27 @@
 {{- if .Values.kubetail.clusterAgent.enabled }}
 {{- $rbac := index .Values "kubetail" "clusterAgent" "rbac" -}}
-# Lets the cluster-agent SA call SubjectAccessReview / TokenReview against the
-# kube-apiserver — the cluster-agent authenticates incoming gRPC clients via
-# mTLS and then delegates per-request authz to the kube-apiserver.
+# The cluster-agent authenticates incoming gRPC clients via mTLS (identity
+# forwarded from cluster-api) and then delegates per-request authz to the
+# kube-apiserver by asking whether the forwarded user can `get pods/log` in
+# the requested namespace. SubjectAccessReview is the only API access it needs
+# — logs are read directly from the node's container-logs directory on disk.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kubetail.clusterAgent.clusterRoleName" $ }}
+  labels:
+    {{- include "kubetail.clusterAgent.labels" (list $ $rbac.labels) | indent 4 }}
+  annotations:
+    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
+rules:
+- apiGroups: [authorization.k8s.io]
+  resources: [subjectaccessreviews]
+  verbs: [create]
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kubetail.clusterAgent.clusterRoleBindingName" $ }}-auth-delegator
+  name: {{ include "kubetail.clusterAgent.clusterRoleBindingName" $ }}
   labels:
     {{- include "kubetail.clusterAgent.labels" (list $ $rbac.labels) | indent 4 }}
   annotations:
@@ -14,7 +29,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:auth-delegator
+  name: {{ include "kubetail.clusterAgent.clusterRoleName" $ }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.clusterAgent.serviceAccountName" $ }}

--- a/charts/kubetail/templates/cluster-api/rbac.yaml
+++ b/charts/kubetail/templates/cluster-api/rbac.yaml
@@ -1,33 +1,24 @@
 {{- if .Values.kubetail.clusterAPI.enabled }}
 {{- $rbac := index .Values "kubetail" "clusterAPI" "rbac" -}}
-{{- $root := . -}}
-{{- range $namespace := uniq (append .Values.kubetail.allowedNamespaces (include "kubetail.namespace" $)) }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: {{ $namespace }}
+  namespace: {{ include "kubetail.namespace" $ }}
   name: {{ include "kubetail.clusterAPI.roleName" $ }}
   labels:
     {{- include "kubetail.clusterAPI.labels" (list $ $rbac.labels) | indent 4 }}
   annotations:
     {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
 rules:
-{{- if eq $namespace (include "kubetail.namespace" $) }}
 - apiGroups: [discovery.k8s.io]
   resources: [endpointslices]
   verbs: [list, watch]
-{{- end }}
-{{- if has $namespace $root.Values.kubetail.allowedNamespaces }}
-- apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
-  verbs: [get, list, watch]
-{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: {{ $namespace }}
+  namespace: {{ include "kubetail.namespace" $ }}
   name: {{ include "kubetail.clusterAPI.roleBindingName" $ }}
   labels:
     {{- include "kubetail.clusterAPI.labels" (list $ $rbac.labels) | indent 4 }}
@@ -41,7 +32,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.clusterAPI.serviceAccountName" $ }}
   namespace: {{ include "kubetail.namespace" $ }}
-{{- end }}
 ---
 # Lets the cluster-api SA call TokenReview / SubjectAccessReview against the
 # kube-apiserver — required for k8s-style delegated auth (the other half of
@@ -96,11 +86,13 @@ rules:
 - apiGroups: [""]
   resources: [nodes]
   verbs: [get, list, watch]
-{{- if not .Values.kubetail.allowedNamespaces }}
+# Workload + pod informers in modules/shared/logs (sourceWatcher) — used to
+# resolve log sources to pods. Cluster-wide so the API can serve logs across
+# all namespaces. Note: no pods/log; pod logs are streamed from the
+# cluster-agent over gRPC, not read via the Kubernetes API.
 - apiGroups: ["", apps, batch]
-  resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
+  resources: [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
   verbs: [get, list, watch]
-{{- end }}
 # Lets cluster-api impersonate the calling user / SA when forwarding requests
 # downstream (e.g. dispatching to the cluster-agent). The aggregation layer
 # delivers the original caller's identity in headers; cluster-api then

--- a/charts/kubetail/templates/dashboard/rbac.yaml
+++ b/charts/kubetail/templates/dashboard/rbac.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.kubetail.dashboard.enabled }}
 {{- $rbac := index .Values "kubetail" "dashboard" "rbac" -}}
+{{- $allowedNamespaces := include "kubetail.allowedNamespaces" $ | fromYamlArray -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,7 +13,7 @@ rules:
 - apiGroups: [""]
   resources: [namespaces, nodes]
   verbs: [get, list, watch]
-{{- if not .Values.kubetail.allowedNamespaces }}
+{{- if not $allowedNamespaces }}
 - apiGroups: ["", apps, batch]
   resources: [cronjobs, daemonsets, deployments, jobs, pods, replicasets, statefulsets]
   verbs: [get, list, watch]
@@ -21,7 +22,7 @@ rules:
 - apiGroups: [authentication.k8s.io]
   resources: [tokenreviews]
   verbs: [create]
-{{- else if not .Values.kubetail.allowedNamespaces }}
+{{- else if not $allowedNamespaces }}
 - apiGroups: [""]
   resources: [pods/log]
   verbs: [get]
@@ -62,8 +63,8 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
   namespace: {{ include "kubetail.namespace" $ }}
-{{- if and (ne .Values.kubetail.dashboard.authMode "token") (.Values.kubetail.allowedNamespaces) }}
-{{- range .Values.kubetail.allowedNamespaces }}
+{{- if and (ne .Values.kubetail.dashboard.authMode "token") ($allowedNamespaces) }}
+{{- range $allowedNamespaces }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubetail/templates/dashboard/rbac.yaml
+++ b/charts/kubetail/templates/dashboard/rbac.yaml
@@ -21,7 +21,7 @@ rules:
 - apiGroups: [authentication.k8s.io]
   resources: [tokenreviews]
   verbs: [create]
-{{- else }}
+{{- else if not .Values.kubetail.allowedNamespaces }}
 - apiGroups: [""]
   resources: [pods/log]
   verbs: [get]
@@ -62,79 +62,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
   namespace: {{ include "kubetail.namespace" $ }}
-{{- if or (eq .Values.kubetail.dashboard.authMode "token") (not .Values.kubetail.allowedNamespaces) }}
-{{- if .Values.kubetail.clusterAPI.enabled }}
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-rules:
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleBindingName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
-  namespace: {{ include "kubetail.namespace" $ }}
-{{- end }}
-{{- end }}
 {{- if and (ne .Values.kubetail.dashboard.authMode "token") (.Values.kubetail.allowedNamespaces) }}
-{{- if not (has (include "kubetail.namespace" $) .Values.kubetail.allowedNamespaces) }}
-{{- if .Values.kubetail.clusterAPI.enabled }}
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-rules:
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{ include "kubetail.namespace" $ }}
-  name: {{ include "kubetail.dashboard.roleBindingName" $ }}
-  labels:
-    {{- include "kubetail.dashboard.labels" (list $ $rbac.labels) | indent 4 }}
-  annotations:
-    {{- include "kubetail.annotations" (list $ $rbac.annotations) | indent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "kubetail.dashboard.roleName" $ }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "kubetail.dashboard.serviceAccountName" $ }}
-  namespace: {{ include "kubetail.namespace" $ }}
-{{- end }}
-{{- end }}
 {{- range .Values.kubetail.allowedNamespaces }}
 ---
 kind: Role
@@ -150,11 +78,6 @@ rules:
 - apiGroups: ["", apps, batch]
   resources: [cronjobs, daemonsets, deployments, jobs, pods, pods/log, replicasets, statefulsets]
   verbs: [get, list, watch]
-{{- if eq . (include "kubetail.namespace" $) }}
-- apiGroups: [discovery.k8s.io]
-  resources: [endpointslices]
-  verbs: [list, watch]
-{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -107,7 +107,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.16.1"
+      tag: "0.16.0-rc1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -18,7 +18,8 @@ namespaceOverride: null
 # ###########################################################################################
 
 kubetail:
-  # --- Restrict namespaces
+  # -- DEPRECATED: use `kubetail.dashboard.allowedNamespace` instead.
+  # This option will be removed in the next version.
   allowedNamespaces: []
 
   # -- Define secrets
@@ -44,6 +45,8 @@ kubetail:
   dashboard:
     # -- Enable/disable dashboard
     enabled: true
+    # -- Restrict Kubetail to a single namespace
+    allowedNamespace: null
     # -- Sets the auth mode
     authMode: auto
 
@@ -107,7 +110,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.16.0-rc1"
+      tag: "0.17.0-rc1"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -110,7 +110,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.17.0-rc1"
+      tag: "0.17.0-rc2"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
<!-- PR title emoji:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

## Summary

Cuts the `0.26.0` release of the chart (currently `0.26.0-rc2`, appVersion `0.25.0-rc2`). It tightens the RBAC granted to each component to follow the principle of least privilege now that pod logs stream from the cluster-agent over gRPC rather than via the Kubernetes API, and it replaces the deprecated list-valued `kubetail.allowedNamespaces` option with a single-value `kubetail.dashboard.allowedNamespace` while keeping existing configs working.

## Key Changes

**RBAC tightening**

- **cluster-agent:** scoped to a dedicated `ClusterRole` granting only `subjectaccessreviews/create` instead of binding to the built-in `system:auth-delegator`. The agent now reads logs directly from the node's container-logs directory on disk and only needs `SubjectAccessReview` to delegate per-request authz to the kube-apiserver.
- **cluster-api:** collapsed the per-namespace `Role`/`RoleBinding` down to the release namespace and dropped `pods/log` plus the per-allowed-namespace workload access. Workload/pod informers remain cluster-wide (minus `pods/log`) since pod logs are now streamed from the cluster-agent over gRPC.
- **dashboard:** removed the now-unused `endpointslices` `Role`/`RoleBinding` and simplified the `pods/log` gating around the allowed-namespaces setting.

**Allowed-namespaces option**

- Added a single-value `kubetail.dashboard.allowedNamespace` option as a replacement for the deprecated list-valued `kubetail.allowedNamespaces`.
- A new `kubetail.allowedNamespaces` helper merges both sources so existing configs keep working.
- `NOTES.txt` now warns when the deprecated option is set; `values.yaml` and `README.md` document the deprecation.

**Version bumps**

- Chart `0.25.1` → `0.26.0-rc2`
- appVersion `0.24.1` → `0.25.0-rc2`
- Dashboard image `0.16.1` → `0.17.0-rc2`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused
