### PR TITLE
🐋 Add priorityClassName support to all components

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.26.0-rc2
-appVersion: "0.25.0-rc2"
+version: 0.26.0-rc3
+appVersion: "0.25.0-rc3"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/templates/cluster-agent/daemon-set.yaml
+++ b/charts/kubetail/templates/cluster-agent/daemon-set.yaml
@@ -26,6 +26,9 @@ spec:
     spec:
       automountServiceAccountToken: true
       serviceAccountName: {{ include "kubetail.clusterAgent.serviceAccountName" $ }}
+      {{- with $podTmpl.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with $podTmpl.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubetail/templates/cluster-api/deployment.yaml
+++ b/charts/kubetail/templates/cluster-api/deployment.yaml
@@ -34,6 +34,9 @@ spec:
     spec:
       automountServiceAccountToken: true
       serviceAccountName: {{ include "kubetail.clusterAPI.serviceAccountName" $ }}
+      {{- with $podTmpl.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with $podTmpl.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubetail/templates/dashboard/deployment.yaml
+++ b/charts/kubetail/templates/dashboard/deployment.yaml
@@ -33,6 +33,9 @@ spec:
     spec:
       automountServiceAccountToken: true
       serviceAccountName: {{ include "kubetail.dashboard.serviceAccountName" $ }}
+      {{- with $podTmpl.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with $podTmpl.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -297,7 +297,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-cluster-api"
       # -- Image tag
-      tag: "0.8.1"
+      tag: "0.8.2"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -148,6 +148,8 @@ kubetail:
       imagePullSecrets: []
       # -- Pod security context
       securityContext: {}
+      # -- Priority class name
+      priorityClassName: ""
       # -- Affinity settings
       affinity: {}
       # -- Node selector settings
@@ -335,6 +337,8 @@ kubetail:
       imagePullSecrets: []
       # -- Pod security context
       securityContext: {}
+      # -- Priority class name
+      priorityClassName: ""
       # -- Affinity settings
       affinity: {}
       # -- Node selector settings
@@ -490,6 +494,8 @@ kubetail:
       # -- Pod security context
       securityContext:
         fsGroup: 0
+      # -- Priority class name
+      priorityClassName: ""
       # -- Affinity settings
       affinity: {}
       # -- Node selector settings


### PR DESCRIPTION
Closes #195

## Summary

This adds the ability to configure a `priorityClassName` on Kubetail's pods. The primary motivation is the cluster-agent DaemonSet: without a priority class, its pods can get stuck in `Pending` when a node is already at its pod capacity, since the scheduler has no way to preempt lower-priority pods to make room. Setting a priority class lets the scheduler evict lower-priority pods so the DaemonSet can land on every eligible node. The same option is exposed on the dashboard and cluster-api deployments for consistency.

This branch also carries the `0.25.0-rc3` chart version bump.

## Key Changes

- Add `podTemplate.priorityClassName` to the cluster-agent DaemonSet, dashboard Deployment, and cluster-api Deployment, rendered only when set so existing installs are unaffected.
- Add the corresponding `priorityClassName: ""` default to each `podTemplate` block in `values.yaml`.
- Bump the chart to `0.25.0-rc3`.

## Checklist

- [x] Add the correct emoji to the PR title
- [x] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused