### PR TITLE
🐋 Bump kubetail to 0.25.0

### DIFF
--- a/charts/kubetail/Chart.yaml
+++ b/charts/kubetail/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - private
   - realtime
 type: application
-version: 0.26.0-rc3
-appVersion: "0.25.0-rc3"
+version: 0.26.0
+appVersion: "0.25.0"
 home: https://github.com/kubetail-org/kubetail
 maintainers:
   - email: andres@kubetail.com

--- a/charts/kubetail/values.yaml
+++ b/charts/kubetail/values.yaml
@@ -110,7 +110,7 @@ kubetail:
       # -- Image repository
       repository: "kubetail-org/kubetail-dashboard"
       # -- Image tag
-      tag: "0.17.0-rc2"
+      tag: "0.17.0"
       # -- Overrides the image tag with an image digest
       digest: null
       # -- Docker image pull policy


### PR DESCRIPTION
## Summary

Finalizes the kubetail 0.25.0 release. The dashboard component was previously pinned to a release candidate; this promotes it to the final 0.17.0 release and drops the release-candidate suffix from the chart version.

## Key Changes

- Bump dashboard image tag from `0.17.0-rc2` to `0.17.0`
- Bump chart `version` from `0.26.0-rc3` to `0.26.0`
- Bump chart `appVersion` from `0.25.0-rc3` to `0.25.0`

cluster-api (`0.8.2`) and cluster-agent (`0.7.1`) are already at their latest releases and are unchanged. No runtime config changes were required.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused